### PR TITLE
Add command for polling Mojang service status

### DIFF
--- a/mcstatus.py
+++ b/mcstatus.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import requests
+import json
+
+mojang_status_link = 'http://status.mojang.com/check'
+
+status = {
+	'green': ':white_check_mark:',
+	'yellow': ':warning:',
+	'red': ':x:',
+}
+
+
+def get_mojang_status():
+	r = requests.get(mojang_status_link)
+
+	if r.status_code != 200:
+		print "Can't get Mojang Status!"
+		return
+	else:
+		status = r.json()
+
+		return build_slack_attachment(status)
+
+
+def build_slack_attachment(data):
+
+	response = {}
+	response['title'] = 'Mojang Status Summary'
+	response['title_link'] = 'https://help.mojang.com/'
+	response['text'] = ''
+	response['mrkdwn_in'] = ['text']
+
+	for service in data:
+		service_name = next (iter (service.keys()))
+		color = service[service_name]
+		stat = status.get(color, ':question:')
+		response['text'] += '%s *%s*\n' % (stat, service_name)
+
+	return response
+
+
+def mcstatus(text, content, sc):
+	message = get_mojang_status()
+ 	content.update({'type': 'message', 'text': ' ', 'attachments': json.dumps([message])})
+	sc.api_call('chat.postMessage', **content)
+	print('Got mojang status')
+	

--- a/nimbus.py
+++ b/nimbus.py
@@ -11,6 +11,7 @@ from slackclient import SlackClient
 
 from link_expander import expand_links
 from player_stats import player_stats
+from mcstatus import mcstatus
 
 
 def get_config(filename):
@@ -30,6 +31,9 @@ def process_message(text, content, sc):
         expand_links(text, content, sc)
     if text.startswith('?player'):
         player_stats(text, content, sc)
+    if text == '?mcstatus':
+        mcstatus(text, content, sc)
+
 
 
 def main(filename):


### PR DESCRIPTION
<img width="301" alt="screen shot 2015-07-13 at 9 16 10 am" src="https://cloud.githubusercontent.com/assets/1526881/8650326/f4fb88c8-293f-11e5-84ae-666dc94feb1b.png">

Slack collapses attachments that are large so the message isn't expanded like that ^ by default.
