### PR TITLE
Correctly display forum bans as punishments rather than warns

### DIFF
--- a/plugins/ocn_link_expander.py
+++ b/plugins/ocn_link_expander.py
@@ -129,7 +129,7 @@ class PunishmentScraper(OCNScraper):
     def format_data(self, d):
         """ generate slack message attachment """
         a = {}
-        verb = 'punished' if d['pun_type'] == 'Ban' or d['pun_type'] == 'Forum Ban' else 'warned'
+        verb = 'punished' if d['pun_type'] == 'Ban' or d['pun_type'] == 'Forum Ban' or d['pun_type'] == 'Kick' else 'warned'
         a['fallback'] = '%s %s by %s with reason "_%s_" (%s)' % \
                         (self.get_slack_link(d['punishee']), verb, self.get_slack_link(d['punisher']), d['reason'],
                          d['when'])

--- a/plugins/ocn_link_expander.py
+++ b/plugins/ocn_link_expander.py
@@ -129,7 +129,7 @@ class PunishmentScraper(OCNScraper):
     def format_data(self, d):
         """ generate slack message attachment """
         a = {}
-        verb = 'punished' if d['pun_type'] == 'Ban' else 'warned'
+        verb = 'punished' if d['pun_type'] == 'Ban' or d['pun_type'] == 'Forum Ban' else 'warned'
         a['fallback'] = '%s %s by %s with reason "_%s_" (%s)' % \
                         (self.get_slack_link(d['punishee']), verb, self.get_slack_link(d['punisher']), d['reason'],
                          d['when'])


### PR DESCRIPTION
This resolves an issue I noticed this morning; currently, if you mention a punishment URL for a forum ban in Slack, the bot will display it as a warning. This changes the wording to 'punished' instead of 'warned'.
