### PR TITLE
Add voting reactions and support for +1 response API calls

### DIFF
--- a/plugins/react.py
+++ b/plugins/react.py
@@ -10,13 +10,27 @@ class React(Plugin):
     def on_event(self, event, response):
         text = event['text']
         response.update(timestamp=event['ts'])
+        morethanonereaction = false
 
         # Add a cloud emoji if anyone mentions Overcast Network
         if re.search(r'(overcast|ocn)', text, re.IGNORECASE):
             response.update(name='cloud')
-
+        
+        # Add hammer and ok emoticon reaction if someone says "appropriate?" (for staff voting)
+        
+        if re.search(r'(appropriate?)', text, re.IGNORECASE):
+            # So that :ok: doesn't get run twice, as we'll call the api on each emoji.
+            morethanonereaction = true
+            # Emoji #1
+            response.update(name='hammer')
+            self.bot.sc.api_call('reactions.add', **response)
+            # Emoji #2
+            response.update(name='ok')
+            self.bot.sc.api_call('reactions.add', **response)
+            
         # Add more reactions here!
+        
 
         # Post reaction if we have an emoji set
-        if response.get('name'):
+        if response.get('name') and not morethanonereaction:
             self.bot.sc.api_call('reactions.add', **response)


### PR DESCRIPTION
As requested by @eudaldca , overcast will provide two voting symbols ( :hammer: , and :ok: ) when a user types a question which requires the vote of some staff members, f.i: "Is xxTheYTPlastixxx **appropriate**?".

Also as it was more than one reaction I had to do the API calling right after changing the variable, and then not calling the last method so that :ok: wouldn't be sent twice; a bit hacky perhaps, but should work.

:wave: 
